### PR TITLE
Add BGM, MESSAG, and SCRIPT Frames

### DIFF
--- a/Libellus Library/Event/Types/Frame/PmdFlags.cs
+++ b/Libellus Library/Event/Types/Frame/PmdFlags.cs
@@ -1,0 +1,51 @@
+﻿using System.Text.Json.Serialization;
+
+namespace LibellusLibrary.Event.Types.Frame
+{
+    internal class PmdFlags
+    {
+        [JsonPropertyOrder(-100)]
+        public ushort FlagNumber { get; set; }
+
+        [JsonPropertyOrder(-99)]
+        public ushort CmpValue { get; set; }
+
+        [JsonPropertyOrder(-98)]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public UnitFlagType FlagType { get; set; }
+
+        [JsonPropertyOrder(-97)]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public UnitGFlagType GFlagType { get; set; }
+
+        internal void ReadData(BinaryReader reader)
+        {
+            FlagNumber = reader.ReadUInt16();
+            CmpValue = reader.ReadUInt16();
+            FlagType = (UnitFlagType)reader.ReadUInt16();
+            GFlagType = (UnitGFlagType)reader.ReadUInt16();
+        }
+
+        internal void WriteData(BinaryWriter writer)
+        {
+            writer?.Write((ushort)FlagNumber);
+            writer?.Write((ushort)CmpValue);
+            writer?.Write((ushort)FlagType);
+            writer?.Write((ushort)GFlagType);
+        }
+
+        internal enum UnitFlagType : short
+        {
+            DISABLE = 0,
+            LOCAL = 1,
+            GLOBAL = 2,
+        }
+
+        internal enum UnitGFlagType : short
+        {
+            EVT = 0,
+            COMMU = 1,
+            SYS = 2,
+        }
+    }
+}

--- a/Libellus Library/Event/Types/Frame/PmdFrameFactory.cs
+++ b/Libellus Library/Event/Types/Frame/PmdFrameFactory.cs
@@ -41,6 +41,7 @@ namespace LibellusLibrary.Event.Types.Frame
 		{
             PmdTargetTypeID.MESSAGE => new PmdTarget_Message(),
             PmdTargetTypeID.SCRIPT => new PmdTarget_Script(),
+			PmdTargetTypeID.BGM => new PmdTarget_Bgm(),
             _ =>new PmdTarget_Unknown()
 		};
 

--- a/Libellus Library/Event/Types/Frame/PmdFrameFactory.cs
+++ b/Libellus Library/Event/Types/Frame/PmdFrameFactory.cs
@@ -39,7 +39,8 @@ namespace LibellusLibrary.Event.Types.Frame
 
 		public static PmdTargetType GetFrameType(PmdTargetTypeID Type) => Type switch
 		{
-			_=>new PmdTarget_Unknown()
+            PmdTargetTypeID.MESSAGE => new PmdTarget_Message(),
+            _ =>new PmdTarget_Unknown()
 		};
 
 		public enum PmdTargetTypeID

--- a/Libellus Library/Event/Types/Frame/PmdFrameFactory.cs
+++ b/Libellus Library/Event/Types/Frame/PmdFrameFactory.cs
@@ -40,6 +40,7 @@ namespace LibellusLibrary.Event.Types.Frame
 		public static PmdTargetType GetFrameType(PmdTargetTypeID Type) => Type switch
 		{
             PmdTargetTypeID.MESSAGE => new PmdTarget_Message(),
+            PmdTargetTypeID.SCRIPT => new PmdTarget_Script(),
             _ =>new PmdTarget_Unknown()
 		};
 

--- a/Libellus Library/Event/Types/Frame/PmdTarget_Bgm.cs
+++ b/Libellus Library/Event/Types/Frame/PmdTarget_Bgm.cs
@@ -1,19 +1,43 @@
-﻿using System;
+﻿using LibellusLibrary.JSON;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace LibellusLibrary.Event.Types.Frame
 {
 	internal class PmdTarget_Bgm : PmdTargetType
 	{
-		protected override void ReadData(BinaryReader reader)
+        [JsonPropertyOrder(-96)]
+        [JsonConverter(typeof(ByteArrayToHexArray))]
+        public byte[] Data { get; set; }
+
+        [JsonPropertyOrder(-95)]
+        public ushort Fade { get; set; }
+
+        [JsonPropertyOrder(-94)]
+        public ushort Id { get; set; }
+
+        [JsonPropertyOrder(-93)]
+        [JsonConverter(typeof(ByteArrayToHexArray))]
+        public byte[] Data2 { get; set; }
+
+        protected override void ReadData(BinaryReader reader)
 		{
+            Data = reader.ReadBytes(12);
+            Fade = reader.ReadUInt16();
+            Id = reader.ReadUInt16();
+            Data2 = reader.ReadBytes(36);
 		}
 
 		protected override void WriteData(BinaryWriter writer)
 		{
+            writer?.Write(Data);
+            writer?.Write(Fade);
+            writer?.Write(Id);
+            writer?.Write(Data2);
 		}
 	}
 }

--- a/Libellus Library/Event/Types/Frame/PmdTarget_Message.cs
+++ b/Libellus Library/Event/Types/Frame/PmdTarget_Message.cs
@@ -1,0 +1,105 @@
+﻿using LibellusLibrary.JSON;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace LibellusLibrary.Event.Types.Frame
+{
+    internal class PmdTarget_Message : PmdTargetType
+    {
+        [JsonPropertyOrder(-100)]
+        [JsonConverter(typeof(ByteArrayToHexArray))]
+        public byte[] Data { get; set; }
+
+        [JsonPropertyOrder(-99)]
+        public PmdMessageFlags Flags { get; set; }
+
+        [JsonPropertyOrder(-98)]
+        public uint MessageIndex { get; set; }
+
+        [JsonPropertyOrder(-97)]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public MessageModeEnum MessageMode { get; set; }
+
+        [JsonPropertyOrder(-96)]
+        [JsonConverter(typeof(ByteArrayToHexArray))]
+        public byte[] Data2 { get; set; }
+
+        internal enum MessageModeEnum : uint
+        {
+            STOP = 0,
+            NO_STOP = 1,
+        }
+
+        protected override void ReadData(BinaryReader reader)
+        {
+            Data = reader.ReadBytes(4);
+            Flags = new PmdMessageFlags();
+            Flags.ReadData(reader);
+            MessageIndex = reader.ReadUInt32();
+            MessageMode = (MessageModeEnum)reader.ReadUInt32();
+            Data2 = reader.ReadBytes(32);
+        }
+
+        protected override void WriteData(BinaryWriter writer)
+        {
+            writer?.Write(Data);
+            Flags.WriteData(writer);
+            writer?.Write(MessageIndex);
+            writer?.Write((uint)MessageMode);
+            writer?.Write(Data2);
+        }
+
+    }
+
+    internal class PmdMessageFlags
+    {
+        [JsonPropertyOrder(-100)]
+        public ushort FlagNumber { get; set; }
+
+        [JsonPropertyOrder(-99)]
+        public ushort CmpValue { get; set; }
+
+        [JsonPropertyOrder(-98)]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public UnitFlagType FlagType { get; set; }
+
+        [JsonPropertyOrder(-97)]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public UnitGFlagType GFlagType { get; set; }
+
+        internal enum UnitFlagType : short
+        {
+            DISABLE = 0,
+            LOCAL = 1,
+            GLOBAL = 2,
+        }
+
+        internal enum UnitGFlagType : short
+        {
+            EVT = 0,
+            COMMU = 1,
+            SYS = 2,
+        }
+
+        internal void ReadData(BinaryReader reader)
+        {
+            FlagNumber = reader.ReadUInt16();
+            CmpValue = reader.ReadUInt16();
+            FlagType = (UnitFlagType)reader.ReadUInt16();
+            GFlagType = (UnitGFlagType)reader.ReadUInt16();
+        }
+
+        internal void WriteData(BinaryWriter writer)
+        {
+            writer?.Write((ushort)FlagNumber);
+            writer?.Write((ushort)CmpValue);
+            writer?.Write((ushort)FlagType);
+            writer?.Write((ushort)GFlagType);
+        }
+
+    }
+}

--- a/Libellus Library/Event/Types/Frame/PmdTarget_Message.cs
+++ b/Libellus Library/Event/Types/Frame/PmdTarget_Message.cs
@@ -5,21 +5,21 @@ namespace LibellusLibrary.Event.Types.Frame
 {
     internal class PmdTarget_Message : PmdTargetType
     {
-        [JsonPropertyOrder(-100)]
+        [JsonPropertyOrder(-96)]
         [JsonConverter(typeof(ByteArrayToHexArray))]
         public byte[] Data { get; set; }
 
-        [JsonPropertyOrder(-99)]
+        [JsonPropertyOrder(-95)]
         public PmdFlags Flags { get; set; }
 
-        [JsonPropertyOrder(-98)]
+        [JsonPropertyOrder(-94)]
         public uint MessageIndex { get; set; }
 
-        [JsonPropertyOrder(-97)]
+        [JsonPropertyOrder(-93)]
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public MessageModeEnum MessageMode { get; set; }
 
-        [JsonPropertyOrder(-96)]
+        [JsonPropertyOrder(-92)]
         [JsonConverter(typeof(ByteArrayToHexArray))]
         public byte[] Data2 { get; set; }
 

--- a/Libellus Library/Event/Types/Frame/PmdTarget_Script.cs
+++ b/Libellus Library/Event/Types/Frame/PmdTarget_Script.cs
@@ -11,21 +11,21 @@ namespace LibellusLibrary.Event.Types.Frame
 {
     internal class PmdTarget_Script : PmdTargetType
     {
-        [JsonPropertyOrder(-100)]
+        [JsonPropertyOrder(-96)]
         [JsonConverter(typeof(ByteArrayToHexArray))]
         public byte[] Data { get; set; }
         
-        [JsonPropertyOrder(-99)]
+        [JsonPropertyOrder(-95)]
         public PmdFlags Flags { get; set; }
 
-        [JsonPropertyOrder(-98)]
+        [JsonPropertyOrder(-94)]
         [JsonConverter(typeof(ByteArrayToHexArray))]
         public byte[] Data2 { get; set; }
 
-        [JsonPropertyOrder(-97)]
+        [JsonPropertyOrder(-93)]
         public ushort ProcedureIndex { get; set; }
 
-        [JsonPropertyOrder(-96)]
+        [JsonPropertyOrder(-92)]
         [JsonConverter(typeof(ByteArrayToHexArray))]
         public byte[] Data3 { get; set; }
 

--- a/Libellus Library/Event/Types/Frame/PmdTarget_Script.cs
+++ b/Libellus Library/Event/Types/Frame/PmdTarget_Script.cs
@@ -1,52 +1,51 @@
 ﻿using LibellusLibrary.JSON;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using static LibellusLibrary.Event.Types.Frame.PmdTarget_Message;
 
 namespace LibellusLibrary.Event.Types.Frame
 {
-    internal class PmdTarget_Message : PmdTargetType
+    internal class PmdTarget_Script : PmdTargetType
     {
         [JsonPropertyOrder(-100)]
         [JsonConverter(typeof(ByteArrayToHexArray))]
         public byte[] Data { get; set; }
-
+        
         [JsonPropertyOrder(-99)]
         public PmdFlags Flags { get; set; }
 
         [JsonPropertyOrder(-98)]
-        public uint MessageIndex { get; set; }
-
-        [JsonPropertyOrder(-97)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
-        public MessageModeEnum MessageMode { get; set; }
-
-        [JsonPropertyOrder(-96)]
         [JsonConverter(typeof(ByteArrayToHexArray))]
         public byte[] Data2 { get; set; }
 
-        internal enum MessageModeEnum : uint
-        {
-            STOP = 0,
-            NO_STOP = 1,
-        }
+        [JsonPropertyOrder(-97)]
+        public ushort ProcedureIndex { get; set; }
+
+        [JsonPropertyOrder(-96)]
+        [JsonConverter(typeof(ByteArrayToHexArray))]
+        public byte[] Data3 { get; set; }
 
         protected override void ReadData(BinaryReader reader)
         {
             Data = reader.ReadBytes(4);
             Flags = new PmdFlags();
             Flags.ReadData(reader);
-            MessageIndex = reader.ReadUInt32();
-            MessageMode = (MessageModeEnum)reader.ReadUInt32();
-            Data2 = reader.ReadBytes(32);
+            Data2 = reader.ReadBytes(6);
+            ProcedureIndex = reader.ReadUInt16();
+            Data3 = reader.ReadBytes(32);
         }
 
         protected override void WriteData(BinaryWriter writer)
         {
             writer?.Write(Data);
             Flags.WriteData(writer);
-            writer?.Write(MessageIndex);
-            writer?.Write((uint)MessageMode);
             writer?.Write(Data2);
+            writer?.Write(ProcedureIndex);
+            writer?.Write(Data3);
         }
-
     }
 }


### PR DESCRIPTION
Adds frame info for BGM, MESSAGE, and SCRIPT. How much is actually documented varies (basically just whatever I happened to know when I did this).

As you can probably see by the commit dates this is something I did ages ago and just left it. I'm making this pr so stuff isn't just floating around in discord chats.